### PR TITLE
Use precompiled regular expressions

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Metrics []struct {
+		Name         string `yaml:"name"`
+		EventMatcher []struct {
+			Key   string `yaml:"key"`
+			Expr  string `yaml:"expr"`
+			regex *regexp.Regexp
+		} `yaml:"event_matcher"`
+		Labels map[string]string `yaml:"labels"`
+	} `yaml:"metrics"`
+}
+
+func NewConfig(reader io.Reader) (*Config, error) {
+
+	var config Config
+	if err := yaml.NewDecoder(reader).Decode(&config); err != nil {
+		return nil, fmt.Errorf("Failed to parse config: %v", err)
+	}
+	for i, metric := range config.Metrics {
+		for n, matcher := range metric.EventMatcher {
+			r, err := regexp.Compile(matcher.Expr)
+			if err != nil {
+				return nil, fmt.Errorf("Regex for metric %s, key %s invalid: %s", metric.Name, matcher.Key, err)
+			}
+			config.Metrics[i].EventMatcher[n].regex = r
+		}
+	}
+
+	return &config, nil
+}

--- a/eventexporter.go
+++ b/eventexporter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -23,10 +23,10 @@ type EventRouter struct {
 	kubeClient     kubernetes.Interface
 	eLister        corelisters.EventLister
 	eListerSynched cache.InformerSynced
-	Config         Config
+	Config         *Config
 }
 
-func NewEventRouter(kubeClient kubernetes.Interface, eventsInformer coreinformers.EventInformer, config Config) *EventRouter {
+func NewEventRouter(kubeClient kubernetes.Interface, eventsInformer coreinformers.EventInformer, config *Config) *EventRouter {
 	kubernetesEventCounterVec = make(map[string]*prometheus.CounterVec)
 
 	for _, metric := range config.Metrics {
@@ -83,7 +83,7 @@ func (er *EventRouter) addEvent(obj interface{}) {
 	filterMatches := LogEvent(e, er)
 	if filterMatches != nil {
 		for _, filterMatch := range filterMatches {
-			prometheusEvent(e, filterMatch.Name, filterMatch.Label)
+			prometheusEvent(e, filterMatch.Name, filterMatch.Labels)
 		}
 	}
 }
@@ -99,7 +99,7 @@ func (er *EventRouter) updateEvent(objOld interface{}, objNew interface{}) {
 	filterMatches := LogEvent(eNew, er)
 	if filterMatches != nil {
 		for _, filterMatch := range filterMatches {
-			prometheusEvent(eNew, filterMatch.Name, filterMatch.Label)
+			prometheusEvent(eNew, filterMatch.Name, filterMatch.Labels)
 		}
 	}
 }

--- a/filter.go
+++ b/filter.go
@@ -66,9 +66,8 @@ OUTER:
 			}
 
 			if err != nil {
-				glog.Errorf("Could not get metric label: %v", err)
-				//TODO: Shouldn't this be a continue?
-				break
+				glog.Errorf("Could not get label '%s' for metric '%s': %v", labelKey, metric.Name, err)
+				continue OUTER
 			}
 
 			l[labelKey] = value

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,64 +1,15 @@
 package main
 
 import (
-	"encoding/json"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
-func TestLogEventMatch(t *testing.T) {
-	var config Config
-	var event *v1.Event
-
-	configYAML, eventJSON := getTestData()
-
-	err := yaml.Unmarshal([]byte(configYAML), &config)
-	require.NoError(t, err, "There should be no error while unmarshaling config")
-
-	err = json.Unmarshal([]byte(eventJSON), &event)
-	require.NoError(t, err, "There should be no error while unmarshaling event")
-
-	matches := LogEvent(event, &EventRouter{Config: config})
-
-	require.Equal(t, 2, len(matches), "There should be exactly two metrics returned")
-	require.Equal(t, "metric_1", matches[0].Name)
-	require.Equal(t, "Testnode", matches[0].Label["node"])
-	require.Equal(t, "Normal", matches[0].Label["type"])
-	require.Equal(t, "metric_2", matches[1].Name)
-	require.Equal(t, "Normal", matches[1].Label["type"])
-}
-
-func TestLogEventEmptyConfig(t *testing.T) {
-	var config Config
-
-	configYAML, _ := getTestData()
-
-	err := yaml.Unmarshal([]byte(configYAML), &config)
-	require.NoError(t, err, "There should be no error while unmarshaling config")
-
-	matches := LogEvent(&v1.Event{}, &EventRouter{})
-
-	require.Equal(t, 0, len(matches), "There should be no metrics returned")
-}
-
-func TestLogEventEmptyEvent(t *testing.T) {
-	var event *v1.Event
-
-	_, eventJSON := getTestData()
-
-	err := json.Unmarshal([]byte(eventJSON), &event)
-	require.NoError(t, err, "There should be no error while unmarshaling event")
-
-	matches := LogEvent(event, &EventRouter{})
-
-	require.Equal(t, 0, len(matches), "There should be no metrics returned")
-}
-
-func getTestData() (string, string) {
-	config := `metrics:
+var (
+	testConfig = []byte(`metrics:
 - name: metric_1
   event_matcher:
   - key: InvolvedObject.Kind
@@ -73,18 +24,64 @@ func getTestData() (string, string) {
   - key: Message
     expr: .*Created container.*
   labels:
-    type: Type`
-
-	event := `{
-		"Message": "Created container",
-		"InvolvedObject": {
-			"Kind": "Pod"
+    type: Type
+`)
+	testEvent = v1.Event{
+		Message: "Created container",
+		InvolvedObject: v1.ObjectReference{
+			Kind: "Pod",
 		},
-		"Source": {
-			"Host": "Testnode"	
+		Source: v1.EventSource{
+			Host: "Testnode",
 		},
-		"Type": "Normal"
-	}`
+		Type: "Normal",
+	}
+)
 
-	return config, event
+func TestLogEventMatch(t *testing.T) {
+	config, err := NewConfig(bytes.NewBuffer(testConfig))
+	require.NoError(t, err, "There should be no error while unmarshaling config")
+
+	matches := LogEvent(&testEvent, &EventRouter{Config: config})
+
+	require.Equal(t, matches, []FilterMatch{
+		FilterMatch{
+			Name:   "metric_1",
+			Labels: map[string]string{"node": testEvent.Source.Host, "type": testEvent.Type},
+		},
+		FilterMatch{
+			Name:   "metric_2",
+			Labels: map[string]string{"type": testEvent.Type},
+		},
+	})
+}
+
+func TestNoMatch(t *testing.T) {
+	config, err := NewConfig(bytes.NewBuffer(testConfig))
+	require.NoError(t, err, "There should be no error while unmarshaling config")
+
+	testEvent = v1.Event{
+		Message: "Other message",
+		Source: v1.EventSource{
+			Host: "Testnode",
+		},
+		Type: "Normal",
+	}
+
+	matches := LogEvent(&testEvent, &EventRouter{Config: config})
+
+	require.Empty(t, matches)
+}
+
+func TestLogEventEmptyConfig(t *testing.T) {
+	matches := LogEvent(&v1.Event{}, &EventRouter{})
+
+	require.Equal(t, 0, len(matches), "There should be no metrics returned")
+}
+
+func TestLogEventEmptyEvent(t *testing.T) {
+
+	matches := LogEvent(&testEvent, &EventRouter{})
+
+	require.Equal(t, 0, len(matches), "There should be no metrics returned")
 }


### PR DESCRIPTION
This commit refactors improves the following things.
* Move config related code into seperate file
* Change loadConfig into NewConfig that works on a reader and can be used in tests as well
* Precompile regular expressions during config load
* Reduce signal handler to SIGINT and SIGQUIT
* Reduce netsing in LogEvent function by using a jump label